### PR TITLE
Moving option httplog from defaults to each frontend

### DIFF
--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -7,7 +7,6 @@ global
 
 defaults
     mode {{props['haproxy']['mode']}}
-    option {{props['haproxy']['logmode']}}
     timeout connect {{props['haproxy']['connect_timeout']}}
     timeout client {{props['haproxy']['client_timeout']}}
     timeout server {{props['haproxy']['server_timeout']}}
@@ -16,6 +15,7 @@ defaults
 
 frontend {{app}}
     mode http
+    option {{props['haproxy']['logmode']}}
     log global
     bind *:{{props['haproxy'][app+"_port"]}}
     default_backend {{app}}


### PR DESCRIPTION
From http://comments.gmane.org/gmane.comp.web.haproxy/3311,

> This is because of "option httplog" in your defaults section. You
> should move it to the sections you that want to log (the same as
> the ones which have "log global").
